### PR TITLE
ci: Enhance build and publish workflows for release automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,9 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+
+      - name: Validate Maven Central publishing setup
+        run: ./gradlew :lib:publishToMavenLocal --dry-run
+
+      - name: Validate Gradle Plugin Portal publishing setup
+        run: ./gradlew :lib:validatePlugins

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-  release:
-    types: [ created ]
+  push:
+    branches: [ production ]
 
 jobs:
   publish:
@@ -32,5 +32,25 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+      - name: Extract version from gradle.properties
+        id: get_version
+        run: echo "version=$(grep VERSION_NAME gradle.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          release_name: Release v${{ steps.get_version.outputs.version }}
+          body: |
+            Automated release v${{ steps.get_version.outputs.version }}
+            
+            Published to:
+            - Maven Central Portal
+            - Gradle Plugin Portal
+          draft: false
+          prerelease: false
 
 


### PR DESCRIPTION
Add validation steps for Maven Central and Gradle Plugin publishing in build workflow to catch publishing issues early.

Change publish trigger from release creation to pushing on production branch for more controlled release deployment.

Automate GitHub release creation with version extracted from gradle.properties, including release notes listing published targets.